### PR TITLE
no sudo on docker execution via galaxy

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -9,6 +9,7 @@
     <destinations default="docker_local">
         <destination id="local" runner="local"/>
         <destination id="docker_local" runner="local">
+            <param id="docker_sudo">false</param>
             <param id="docker_enabled">true</param>
             <param id="docker_volumes">$defaults,/disk/reference:ro</param>
             <param id="docker_net">bridge</param>

--- a/scripts/01_install.sh
+++ b/scripts/01_install.sh
@@ -13,6 +13,9 @@ sudo apt-get update
 sudo apt-get install -y --force-yes docker-engine
 sudo apt-get install -y default-jdk gfortran g++
 
+# Add user 'ubuntu' to group 'docker'
+sudo usermod -aG docker ${USER}
+
 # INSTALLING PYTHON
 mkdir ~/galaxy-python
 cd ~/galaxy-python
@@ -37,5 +40,4 @@ python --version
 cd
 git clone -b release_16.10 https://github.com/galaxyproject/galaxy.git
 cd galaxy
-./run.sh 
-
+./run.sh


### PR DESCRIPTION
dockerを使うときにsudoを打つと `sudo: no tty present and no askpass program specified ` というエラーが出るので、ubuntu ユーザを docker group に入れて、galaxy 経由の docker コマンドで sudo を使わないように job conf で設定する。